### PR TITLE
Combined theirstory changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2797,9 +2797,9 @@
       "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ=="
     },
     "align-diarized-text": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/align-diarized-text/-/align-diarized-text-1.0.7.tgz",
-      "integrity": "sha512-oJokSu6DtE1tJcw/pfX5V280T69yOcEuaRcdQzDNXA/MEBXus6eAvWJYlBh7WwWBlMepM0QMHzdeAZ/LSvwb9w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/align-diarized-text/-/align-diarized-text-1.0.8.tgz",
+      "integrity": "sha512-fOaPEPT2KVAfzjUvtDVSVLaQ7KlKOxtjqrqZC+K5MCMDNS85nA8g9d8Uw8tjqHXsK33D1CqUnuJdAJFTdNIjWA==",
       "requires": {
         "alignment-from-stt": "^1.0.2",
         "convert-csv-to-json": "0.0.15",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@fortawesome/react-fontawesome": "^0.1.5",
     "@storybook/addon-storysource": "^5.3.18",
-    "align-diarized-text": "^1.0.8",
+    "align-diarized-text": "^1.0.9",
     "docx": "4.7.1",
     "prop-types": "^15.7.2",
     "react-bootstrap": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.12.1",
     "@fortawesome/react-fontawesome": "^0.1.5",
     "@storybook/addon-storysource": "^5.3.18",
-    "align-diarized-text": "^1.0.7",
+    "align-diarized-text": "^1.0.8",
     "docx": "4.7.1",
     "prop-types": "^15.7.2",
     "react-bootstrap": "^1.0.1",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -382,12 +382,12 @@ export default function SlateTranscriptEditor(props) {
   };
 
   const handleSubtitlesExport = ({ type, ext }) => {
-    let editorContnet = getEditorContent({
+    let editorContent = getEditorContent({
       type: 'json-digitalpaperedit',
       speakers: true,
       timecodes: true,
     });
-    let subtitlesJson = subtitlesGenerator({ words: editorContnet.words, type });
+    let subtitlesJson = subtitlesGenerator({ words: editorContent.words, paragraphs: editorContent.paragraphs, type });
     if (type === 'json') {
       subtitlesJson = JSON.stringify(subtitlesJson, null, 2);
     }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -35,7 +35,7 @@ import { shortTimecode } from '../util/timecode-converter';
 import slateToText from '../util/export-adapters/txt';
 import download from '../util/downlaod/index.js';
 import convertDpeToSlate from '../util/dpe-to-slate';
-import converSlateToDpe from '../util/export-adapters/slate-to-dpe/index.js';
+import converSlateToDpe, { convertSlateToDpeAsync } from '../util/export-adapters/slate-to-dpe/index.js';
 import slateToDocx from '../util/export-adapters/docx';
 import restoreTimecodes from '../util/restore-timcodes';
 import insertTimecodesInline from '../util/inline-interval-timecodes';
@@ -70,6 +70,16 @@ export default function SlateTranscriptEditor(props) {
   const [showSpeakersCheatShet, setShowSpeakersCheatShet] = useState(false);
   const [saveTimer, setSaveTimer] = useState(null);
   const [isPauseWhiletyping, setIsPauseWhiletyping] = useState(false);
+
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  useEffect(() => {
+    if (isProcessing) {
+      document.body.style.cursor = 'wait';
+    } else {
+      document.body.style.cursor = 'default';
+    }
+  }, [isProcessing]);
 
   useEffect(() => {
     if (props.transcriptData) {
@@ -291,22 +301,22 @@ export default function SlateTranscriptEditor(props) {
     }
   };
 
-  const getEditorContent = ({ type, speakers, timecodes, inline_timecodes: inline, hideTitle, atlasFormat }) => {
+  const getEditorContent = async ({ type, speakers, timecodes, inline_timecodes: inline, hideTitle, atlasFormat }) => {
     switch (type) {
       case 'text':
         let tmpValue = value;
         if (timecodes || inline) {
-          tmpValue = handleRestoreTimecodes(inline);
+          tmpValue = await handleRestoreTimecodes(inline);
         }
         return slateToText({ value: tmpValue, speakers, timecodes, atlasFormat });
       case 'json-slate':
         return value;
       case 'json-digitalpaperedit':
-        return converSlateToDpe(value, props.transcriptData);
+        return convertSlateToDpeAsync(value, props.transcriptData);
       case 'word':
         let docTmpValue = value;
         if (timecodes || inline) {
-          docTmpValue = handleRestoreTimecodes(inline);
+          docTmpValue = await handleRestoreTimecodes(inline);
         }
         return slateToDocx({ value: docTmpValue, speakers, timecodes, inline_speakers: inline, title: props.title, hideTitle });
       default:
@@ -321,35 +331,45 @@ export default function SlateTranscriptEditor(props) {
     }
     return path.basename(props.mediaUrl).trim();
   };
-  const handleExport = ({ type, ext, speakers, timecodes, inline_timecodes, hideTitle, atlasFormat }) => {
-    let editorContnet = getEditorContent({ type, speakers, inline_timecodes, timecodes, hideTitle, atlasFormat });
-    if (ext === 'json') {
-      editorContnet = JSON.stringify(editorContnet, null, 2);
-    }
-    if (ext !== 'docx') {
-      download(editorContnet, `${getFileTitle()}.${ext}`);
-    }
-  };
-
-  const handleSave = () => {
-    const format = props.autoSaveContentType ? props.autoSaveContentType : 'digitalpaperedit';
-    const editorContnet = getEditorContent({ type: `json-${format}` });
-    if (props.handleSaveEditor) {
-      props.handleSaveEditor(editorContnet);
+  const handleExport = async ({ type, ext, speakers, timecodes, inline_timecodes, hideTitle, atlasFormat }) => {
+    try {
+      setIsProcessing(true);
+      let editorContnet = await getEditorContent({ type, speakers, inline_timecodes, timecodes, hideTitle, atlasFormat });
+      if (ext === 'json') {
+        editorContnet = JSON.stringify(editorContnet, null, 2);
+      }
+      if (ext !== 'docx') {
+        download(editorContnet, `${getFileTitle()}.${ext}`);
+      }
+    } finally {
+      setIsProcessing(false);
     }
   };
 
-  const handleRestoreTimecodes = (inline_timecodes = false) => {
+  const handleSave = async () => {
+    try {
+      setIsProcessing(true);
+      const format = props.autoSaveContentType ? props.autoSaveContentType : 'digitalpaperedit';
+      const editorContnet = await getEditorContent({ type: `json-${format}` });
+      if (props.handleSaveEditor) {
+        props.handleSaveEditor(editorContnet);
+      }
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleRestoreTimecodes = async (inline_timecodes = false) => {
     if (inline_timecodes) {
       let transcriptData = insertTimecodesInline({ transcriptData: props.transcriptData });
-      const ret = restoreTimecodes({
+      const ret = await restoreTimecodes({
         transcriptData,
         slateValue: convertDpeToSlate(transcriptData),
       });
       handleRestoreTimecodes(false);
       return ret;
     } else {
-      const alignedSlateData = restoreTimecodes({
+      const alignedSlateData = await restoreTimecodes({
         slateValue: value,
         transcriptData: props.transcriptData,
       });
@@ -392,17 +412,22 @@ export default function SlateTranscriptEditor(props) {
     setIsPauseWhiletyping(!isPauseWhiletyping);
   };
 
-  const handleSubtitlesExport = ({ type, ext }) => {
-    let editorContent = getEditorContent({
-      type: 'json-digitalpaperedit',
-      speakers: true,
-      timecodes: true,
-    });
-    let subtitlesJson = subtitlesGenerator({ words: editorContent.words, paragraphs: editorContent.paragraphs, type });
-    if (type === 'json') {
-      subtitlesJson = JSON.stringify(subtitlesJson, null, 2);
+  const handleSubtitlesExport = async ({ type, ext }) => {
+    try {
+      setIsProcessing(true);
+      let editorContent = await getEditorContent({
+        type: 'json-digitalpaperedit',
+        speakers: true,
+        timecodes: true,
+      });
+      let subtitlesJson = subtitlesGenerator({ words: editorContent.words, paragraphs: editorContent.paragraphs, type });
+      if (type === 'json') {
+        subtitlesJson = JSON.stringify(subtitlesJson, null, 2);
+      }
+      download(subtitlesJson, `${getFileTitle()}.${ext}`);
+    } finally {
+      setIsProcessing(false);
     }
-    download(subtitlesJson, `${getFileTitle()}.${ext}`);
   };
 
   const getMediaType = () => {
@@ -609,7 +634,7 @@ export default function SlateTranscriptEditor(props) {
                 overlay={<Tooltip id="tooltip-disabled">Export options</Tooltip>}
               >
                 <span className="d-inline-block">
-                  <DropdownButton id="dropdown-basic-button" title={<FontAwesomeIcon icon={faShare} />} variant="light">
+                  <DropdownButton disabled={isProcessing} id="dropdown-basic-button" title={<FontAwesomeIcon icon={faShare} />} variant="light">
                     {/* TODO: need to run re-alignement if exportin with timecodes true, otherwise they'll be inaccurate */}
                     <Dropdown.Item
                       onClick={() => {
@@ -769,7 +794,12 @@ export default function SlateTranscriptEditor(props) {
                 placement={'bottom'}
                 overlay={<Tooltip id="tooltip-disabled">Export in caption format</Tooltip>}
               >
-                <DropdownButton id="dropdown-basic-button" title={<FontAwesomeIcon icon={faClosedCaptioning} />} variant="light">
+                <DropdownButton
+                  disabled={isProcessing}
+                  id="dropdown-basic-button"
+                  title={<FontAwesomeIcon icon={faClosedCaptioning} />}
+                  variant="light"
+                >
                   {subtitlesExportOptionsList.map(({ type, label, ext }, index) => {
                     return (
                       <Dropdown.Item
@@ -792,7 +822,7 @@ export default function SlateTranscriptEditor(props) {
                 placement={'bottom'}
                 overlay={<Tooltip id="tooltip-disabled">Save</Tooltip>}
               >
-                <Button onClick={handleSave} variant="light">
+                <Button disabled={isProcessing} onClick={handleSave} variant="light">
                   <FontAwesomeIcon icon={faSave} />
                 </Button>
               </OverlayTrigger>
@@ -808,7 +838,7 @@ export default function SlateTranscriptEditor(props) {
                   </Tooltip>
                 }
               >
-                <Button onClick={breakParagraph} variant="light">
+                <Button disabled={isProcessing} onClick={breakParagraph} variant="light">
                   {/* <FontAwesomeIcon icon={ faICursor } /> */}↵
                 </Button>
               </OverlayTrigger>
@@ -821,7 +851,7 @@ export default function SlateTranscriptEditor(props) {
                   <Tooltip id="tooltip-disabled">Put the cursor at a point where you'd want to add [INAUDIBLE] text, and click this button</Tooltip>
                 }
               >
-                <Button onClick={insertTextInaudible} variant="light">
+                <Button disabled={isProcessing} onClick={insertTextInaudible} variant="light">
                   <FontAwesomeIcon icon={faMehBlank} />
                 </Button>
               </OverlayTrigger>
@@ -837,7 +867,7 @@ export default function SlateTranscriptEditor(props) {
                   </Tooltip>
                 }
               >
-                <Button onClick={handleSetPauseWhileTyping} variant={isPauseWhiletyping ? 'secondary' : 'light'}>
+                <Button disabled={isProcessing} onClick={handleSetPauseWhileTyping} variant={isPauseWhiletyping ? 'secondary' : 'light'}>
                   <FontAwesomeIcon icon={faPause} />
                 </Button>
               </OverlayTrigger>
@@ -852,7 +882,18 @@ export default function SlateTranscriptEditor(props) {
                   </Tooltip>
                 }
               >
-                <Button onClick={handleRestoreTimecodes} variant="light">
+                <Button
+                  disabled={isProcessing}
+                  onClick={async () => {
+                    try {
+                      setIsProcessing(true);
+                      await handleRestoreTimecodes();
+                    } finally {
+                      setIsProcessing(false);
+                    }
+                  }}
+                  variant="light"
+                >
                   <FontAwesomeIcon icon={faSync} />
                 </Button>
               </OverlayTrigger>
@@ -867,7 +908,7 @@ export default function SlateTranscriptEditor(props) {
                 }
               >
                 {/* <span className="d-inline-block"> */}
-                <Button variant="light">
+                <Button disabled={isProcessing} variant="light">
                   <FontAwesomeIcon icon={faInfoCircle} />
                 </Button>
                 {/* </span> */}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -724,7 +724,7 @@ export default function SlateTranscriptEditor(props) {
                         handleExport({
                           type: 'word',
                           ext: 'docx',
-                          speakers: true,
+                          speakers: false,
                           timecodes: false,
                           inline_timecodes: true,
                           hideTitle: true,

--- a/src/util/export-adapters/docx/index.js
+++ b/src/util/export-adapters/docx/index.js
@@ -3,26 +3,37 @@ import { shortTimecode } from '../../timecode-converter/';
 import { Node } from 'slate';
 export default slateToDocx;
 
-function slateToDocx({ value, speakers, timecodes, title = 'Transcript', creator = 'Slate Transcript Editor', description = 'Transcript' }) {
+function slateToDocx({
+  value,
+  speakers,
+  timecodes,
+  inline_speakers,
+  hideTitle,
+  title = 'Transcript',
+  creator = 'Slate Transcript Editor',
+  description = 'Transcript',
+}) {
   const doc = new Document({
     creator: creator,
     description: description,
     title: title,
   });
 
-  // Transcript Title
-  // TODO: get title in programmatically - optional value
-  const textTitle = new TextRun(title);
-  const paragraphTitle = new Paragraph();
-  paragraphTitle.addRun(textTitle);
-  paragraphTitle.heading1().center();
-  doc.addParagraph(paragraphTitle);
+  if (!hideTitle) {
+    // Transcript Title
+    // TODO: get title in programmatically - optional value
+    const textTitle = new TextRun(title);
+    const paragraphTitle = new Paragraph();
+    paragraphTitle.addRun(textTitle);
+    paragraphTitle.heading1().center();
+    doc.addParagraph(paragraphTitle);
+  }
 
   // add spacing
   var paragraphEmpty = new Paragraph();
   doc.addParagraph(paragraphEmpty);
 
-  value.forEach(slateParagraph => {
+  value.forEach((slateParagraph) => {
     console.log('slateParagraph', slateParagraph);
     // TODO: use timecode converter module to convert from seconds to timecode
 
@@ -31,7 +42,7 @@ function slateToDocx({ value, speakers, timecodes, title = 'Transcript', creator
       const timecodeStartTime = new TextRun(shortTimecode(slateParagraph.start));
       paragraphSpeakerTimecodes.addRun(timecodeStartTime);
     }
-    if (speakers) {
+    if (speakers || inline_speakers) {
       if (timecodes) {
         const speaker = new TextRun(slateParagraph.speaker).bold().tab();
         paragraphSpeakerTimecodes.addRun(speaker);
@@ -40,20 +51,28 @@ function slateToDocx({ value, speakers, timecodes, title = 'Transcript', creator
         paragraphSpeakerTimecodes.addRun(speaker);
       }
     }
-    if (timecodes || speakers) {
+
+    const paragraphContents = Node.string(slateParagraph);
+    const textBreak = new TextRun('').break();
+
+    if (inline_speakers) {
+      paragraphSpeakerTimecodes.addRun(new TextRun(paragraphContents).tab()).addRun(textBreak);
+    }
+
+    if (timecodes || speakers || inline_speakers) {
       doc.addParagraph(paragraphSpeakerTimecodes);
     }
 
-    const paragraphText = new Paragraph(Node.string(slateParagraph));
-    const textBreak = new TextRun('').break();
-    // const paragraphText = new Paragraph(slateParagraph.children[0].text);
-    paragraphText.addRun(textBreak);
-    doc.addParagraph(paragraphText);
+    if (!inline_speakers) {
+      const paragraphText = new Paragraph(paragraphContents);
+      paragraphText.addRun(textBreak);
+      doc.addParagraph(paragraphText);
+    }
   });
 
   const packer = new Packer();
 
-  packer.toBlob(doc).then(blob => {
+  packer.toBlob(doc).then((blob) => {
     const filename = `${title}.docx`;
     // // const type =  'application/octet-stream';
     const a = document.createElement('a');

--- a/src/util/export-adapters/docx/index.js
+++ b/src/util/export-adapters/docx/index.js
@@ -42,12 +42,12 @@ function slateToDocx({
       const timecodeStartTime = new TextRun(shortTimecode(slateParagraph.start));
       paragraphSpeakerTimecodes.addRun(timecodeStartTime);
     }
-    if (speakers || inline_speakers) {
+    if (speakers) {
       if (timecodes) {
         const speaker = new TextRun(slateParagraph.speaker).bold().tab();
         paragraphSpeakerTimecodes.addRun(speaker);
       } else {
-        const speaker = new TextRun(inline_speakers ? slateParagraph.speaker.toUpperCase() : slateParagraph.speaker).bold();
+        const speaker = new TextRun(slateParagraph.speaker).bold();
         paragraphSpeakerTimecodes.addRun(speaker);
       }
     }
@@ -56,11 +56,12 @@ function slateToDocx({
     const textBreak = new TextRun('').break();
 
     if (inline_speakers) {
-      paragraphSpeakerTimecodes.addRun(new TextRun(`:  ${paragraphContents}`)).addRun(textBreak);
+      paragraphSpeakerTimecodes.addRun(new TextRun(`${slateParagraph.speaker.toUpperCase()}:  ${paragraphContents}`));
     }
 
     if (timecodes || speakers || inline_speakers) {
       doc.addParagraph(paragraphSpeakerTimecodes);
+      doc.addParagraph(new Paragraph());
     }
 
     if (!inline_speakers) {

--- a/src/util/export-adapters/docx/index.js
+++ b/src/util/export-adapters/docx/index.js
@@ -56,7 +56,7 @@ function slateToDocx({
     const textBreak = new TextRun('').break();
 
     if (inline_speakers) {
-      paragraphSpeakerTimecodes.addRun(new TextRun(`: ${paragraphContents}`)).addRun(textBreak);
+      paragraphSpeakerTimecodes.addRun(new TextRun(`:  ${paragraphContents}`)).addRun(textBreak);
     }
 
     if (timecodes || speakers || inline_speakers) {

--- a/src/util/export-adapters/docx/index.js
+++ b/src/util/export-adapters/docx/index.js
@@ -27,11 +27,11 @@ function slateToDocx({
     paragraphTitle.addRun(textTitle);
     paragraphTitle.heading1().center();
     doc.addParagraph(paragraphTitle);
-  }
 
-  // add spacing
-  var paragraphEmpty = new Paragraph();
-  doc.addParagraph(paragraphEmpty);
+    // add spacing
+    var paragraphEmpty = new Paragraph();
+    doc.addParagraph(paragraphEmpty);
+  }
 
   value.forEach((slateParagraph) => {
     console.log('slateParagraph', slateParagraph);
@@ -47,7 +47,7 @@ function slateToDocx({
         const speaker = new TextRun(slateParagraph.speaker).bold().tab();
         paragraphSpeakerTimecodes.addRun(speaker);
       } else {
-        const speaker = new TextRun(slateParagraph.speaker).bold();
+        const speaker = new TextRun(inline_speakers ? slateParagraph.speaker.toUpperCase() : slateParagraph.speaker).bold();
         paragraphSpeakerTimecodes.addRun(speaker);
       }
     }
@@ -56,7 +56,7 @@ function slateToDocx({
     const textBreak = new TextRun('').break();
 
     if (inline_speakers) {
-      paragraphSpeakerTimecodes.addRun(new TextRun(paragraphContents).tab()).addRun(textBreak);
+      paragraphSpeakerTimecodes.addRun(new TextRun(`: ${paragraphContents}`)).addRun(textBreak);
     }
 
     if (timecodes || speakers || inline_speakers) {

--- a/src/util/export-adapters/slate-to-dpe/align_worker.js
+++ b/src/util/export-adapters/slate-to-dpe/align_worker.js
@@ -1,0 +1,6 @@
+import alignDiraizedText from 'align-diarized-text/src/index';
+
+addEventListener('message', (event) => {
+  const response = alignDiraizedText(...event.data);
+  postMessage(response);
+});

--- a/src/util/export-adapters/subtitles-generator/compose-subtitles/vtt.js
+++ b/src/util/export-adapters/subtitles-generator/compose-subtitles/vtt.js
@@ -1,9 +1,9 @@
 import formatSeconds from './util/format-seconds.js';
 
-const vttGenerator = vttJSON => {
+const vttGenerator = (vttJSON, speakers=false) => {
   let vttOut = 'WEBVTT\n\n';
   vttJSON.forEach((v, i) => {
-    vttOut += `${i + 1}\n${formatSeconds(parseFloat(v.start))} --> ${formatSeconds(parseFloat(v.end))}\n${v.text}\n\n`;
+    vttOut += `${i + 1}\n${formatSeconds(parseFloat(v.start))} --> ${formatSeconds(parseFloat(v.end))}\n${speakers ? `<v ${v.speaker}>` : ``}${v.text}\n\n`;
   });
 
   return vttOut;

--- a/src/util/export-adapters/subtitles-generator/index.js
+++ b/src/util/export-adapters/subtitles-generator/index.js
@@ -23,7 +23,7 @@ function segmentedTextToList(text) {
 }
 
 function countWords(text) {
-  return text.trim().replace(/\n /g, '').replace(/\n/g, ' ').split(' ').length;
+  return text.trim().replace(/\s\s+/g, ' ').split(' ').length;
 }
 
 function addTimecodesToLines(wordsList, paragraphs, lines) {

--- a/src/util/export-adapters/subtitles-generator/list.js
+++ b/src/util/export-adapters/subtitles-generator/list.js
@@ -1,6 +1,7 @@
 const subtitlesExportOptionsList = [
   { type: 'srt', label: 'Srt', ext: 'srt' },
   { type: 'vtt', label: 'VTT', ext: 'vtt' },
+  { type: 'vtt_speakers', label: 'VTT with speakers', ext: 'vtt' },
   { type: 'itt', label: 'iTT', ext: 'itt' },
   { type: 'ttml', label: 'TTML', ext: 'ttml' },
   { type: 'premiereTTML', label: 'TTML for Adobe Premiere', ext: 'ttml' },

--- a/src/util/export-adapters/subtitles-generator/list.js
+++ b/src/util/export-adapters/subtitles-generator/list.js
@@ -2,6 +2,7 @@ const subtitlesExportOptionsList = [
   { type: 'srt', label: 'Srt', ext: 'srt' },
   { type: 'vtt', label: 'VTT', ext: 'vtt' },
   { type: 'vtt_speakers', label: 'VTT with speakers', ext: 'vtt' },
+  { type: 'vtt_speakers_paragraphs', label: 'VTT with speakers and paragraphs', ext: 'vtt' },
   { type: 'itt', label: 'iTT', ext: 'itt' },
   { type: 'ttml', label: 'TTML', ext: 'ttml' },
   { type: 'premiereTTML', label: 'TTML for Adobe Premiere', ext: 'ttml' },

--- a/src/util/inline-interval-timecodes/index.js
+++ b/src/util/inline-interval-timecodes/index.js
@@ -1,0 +1,23 @@
+import secondsToTimecode from '../timecode-converter/src/secondsToTimecode';
+
+const insertTimecodesInline = ({ intervalSeconds = 30, transcriptData }) => {
+  let lastInsertTime = 0;
+
+  const sortedWords = transcriptData.words.sort((a, b) => a.start - b.start);
+
+  let newWords = [];
+  for (const word of sortedWords) {
+    if (word.start - lastInsertTime > intervalSeconds) {
+      lastInsertTime = Math.floor(word.start / intervalSeconds) * intervalSeconds;
+      const timecode = secondsToTimecode(lastInsertTime);
+      newWords.push({ start: word.start, end: word.start + (word.end - word.start) / 2, text: `[${timecode}]` });
+      word.start = word.start + (word.end - word.start) / 2;
+    }
+    newWords.push(word);
+  }
+  return {
+    ...transcriptData,
+    words: newWords,
+  };
+};
+export default insertTimecodesInline;

--- a/src/util/inline-interval-timecodes/index.js
+++ b/src/util/inline-interval-timecodes/index.js
@@ -1,4 +1,4 @@
-import secondsToTimecode from '../timecode-converter/src/secondsToTimecode';
+import { shortTimecode } from '../timecode-converter';
 
 const insertTimecodesInline = ({ intervalSeconds = 30, transcriptData }) => {
   let lastInsertTime = 0;
@@ -9,7 +9,7 @@ const insertTimecodesInline = ({ intervalSeconds = 30, transcriptData }) => {
   for (const word of sortedWords) {
     if (word.start - lastInsertTime > intervalSeconds) {
       lastInsertTime = Math.floor(word.start / intervalSeconds) * intervalSeconds;
-      const timecode = secondsToTimecode(lastInsertTime);
+      const timecode = shortTimecode(lastInsertTime);
       newWords.push({ start: word.start, end: word.start + (word.end - word.start) / 2, text: `[${timecode}]` });
       word.start = word.start + (word.end - word.start) / 2;
     }

--- a/src/util/restore-timcodes/index.js
+++ b/src/util/restore-timcodes/index.js
@@ -1,8 +1,8 @@
 import convertDpeToSlate from '../dpe-to-slate';
-import converSlateToDpe from '../export-adapters/slate-to-dpe/index.js';
+import { convertSlateToDpeAsync } from '../export-adapters/slate-to-dpe/index.js';
 
-const restoreTimecodes = ({ slateValue, transcriptData }) => {
-  const aligneDpeData = converSlateToDpe(slateValue, transcriptData);
+const restoreTimecodes = async ({ slateValue, transcriptData }) => {
+  const aligneDpeData = await convertSlateToDpeAsync(slateValue, transcriptData);
   const alignedSlateData = convertDpeToSlate(aligneDpeData);
   return alignedSlateData;
 };


### PR DESCRIPTION
We have been working on adding some features to the transcript editor that were requested by some of our customers, as well as fixing any bugs we find. This PR contains the past few weeks of work. Importantly, there's also a [pull request](https://github.com/pietrop/align-diarized-text/pull/5) in `align-diarized-text` to significantly improve some of the performance issues we were seeing in longer transcripts, so I left out the commits in here bumping that dependency as I imagine you'll do it when you merge :)

* Add `VTT with speakers` export option to include speaker info in the regular `.vtt` export, in the correct vtt syntax
* Add `VTT with speakers and paragraphs` to generate an export in `.vtt` format, but instead of splitting by max characters on screen, we split by paragraph.
* Add `Word (OHMS)` export option to generate a `.docx` file in the format expected by OHMS
* Fix bug in subtitle exporter where multiple spaces anywhere in a transcript would throw off the word count resulting in a crash
* **New:** Run `align-diarized-text` in a background task to prevent hanging the browser. This should work by itself, but we paired it with the webpack [worker-plugin](https://github.com/GoogleChromeLabs/worker-plugin) which works nicely. 

If you'd like to review/merge these individually I'm happy to make separate PRs for each feature/fix, it was just easier to package it as one :)