### PR TITLE
fix: Creating a new paragraph at the end of an existing one

### DIFF
--- a/src/components/slate-helpers/handle-split-paragraph/index.js
+++ b/src/components/slate-helpers/handle-split-paragraph/index.js
@@ -62,7 +62,7 @@ function handleSplitParagraph(editor) {
         words: wordsBefore,
       });
       // adjust start time (start and startTimecode) of second block, which is start time of second lsit of words
-      const startTimeSecondParagraph = wordsAfter[0].start;
+      const startTimeSecondParagraph = wordsAfter.length > 0 ? wordsAfter[0].start : wordsBefore[wordsBefore.length - 1].end;
       const blockParagraphAfter = SlateHelpers.createNewParagraphBlock({
         speaker,
         start: startTimeSecondParagraph,


### PR DESCRIPTION
Currently, trying to add a paragraph by pressing enter with the cursor at the end of an existing paragraph fails with the following error:

```
index.js:65 Uncaught (in promise) TypeError: Cannot read property 'start' of undefined
    at Object.handleSplitParagraph (index.js:65)
    at _callee4$ (index.js:458)
    at tryCatch (runtime.js:63)
    at Generator.invoke [as _invoke] (runtime.js:293)
    at Generator.next (runtime.js:118)
    at asyncGeneratorStep (asyncToGenerator.js:3)
    at _next (asyncToGenerator.js:25)
    at asyncToGenerator.js:32
    at new Promise (<anonymous>)
    at asyncToGenerator.js:21
    at handleOnKeyDown (index.js:449)
    at isEventHandled (index.es.js:2309)
    at index.es.js:2025
...
```

Which is actually this line: 

https://github.com/pietrop/slate-transcript-editor/blob/0607306b06732b9b0690abed5a53ecee19037a23/src/components/slate-helpers/handle-split-paragraph/index.js#L65

because there are no words after the cursor in the current paragraph.

**Describe what the PR does**    
I figured that a decent solution would be to just take the end time of the most recent previous word. Thooghts?


**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

Ready!