### PR TITLE
fix #44 - save btn indicator goes away on alignment

### DIFF
--- a/src/components/1-SlateTranscriptEditor.stories.js
+++ b/src/components/1-SlateTranscriptEditor.stories.js
@@ -41,9 +41,9 @@ export const demo = () => {
       <SlateTranscriptEditor
         mediaUrl={text('mediaUrl', DEMO_MEDIA_URL_SOLEIO)}
         handleSaveEditor={action('handleSaveEditor')}
-        handleAutoSaveChanges={action('handleAutoSaveChanges')}
+        // handleAutoSaveChanges={action('handleAutoSaveChanges')}
         // https://www.npmjs.com/package/@storybook/addon-knobs#select
-        autoSaveContentType={select('autoSaveContentType', ['digitalpaperedit', 'slate'], 'digitalpaperedit')} // digitalpaperedit or slate - digitalpaperedit, runs alignement before exporting, slate, is just the raw data.
+        // autoSaveContentType={select('autoSaveContentType', ['digitalpaperedit', 'slate'], 'digitalpaperedit')} // digitalpaperedit or slate - digitalpaperedit, runs alignement before exporting, slate, is just the raw data.
         // transcriptData={object('transcriptData', DEMO_SOLEIO)}
         transcriptData={DEMO_SOLEIO}
       />

--- a/src/components/5-Saving.stories.js
+++ b/src/components/5-Saving.stories.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, text, boolean, number, object, select } from '@storybook/addon-knobs';
+import { withInfo } from '@storybook/addon-info';
+import { version } from '../../package.json';
+
+import SlateTranscriptEditor from './index.js';
+import 'fontsource-roboto';
+
+export default {
+  title: 'Saving indicator',
+  component: SlateTranscriptEditor,
+  decorators: [withKnobs, withInfo],
+  parameters: {
+    info: {
+      maxPropArrayLength: 3,
+      maxPropsIntoLine: 3,
+      maxPropObjectKeys: 1,
+      excludedPropTypes: ['transcriptData'],
+      source: false,
+    },
+  },
+};
+
+const DEMO_MEDIA_URL_SOLEIO =
+  'https://digital-paper-edit-demo.s3.eu-west-2.amazonaws.com/PBS-Frontline/The+Facebook+Dilemma+-+interviews/The+Facebook+Dilemma+-+Soleio+Cuervo-OIAUfZBd_7w.mp4';
+const DEMO_TITLE_SOLEIO = 'Soleio Interview, PBS Frontline';
+import DEMO_SOLEIO from '../sample-data/soleio-dpe.json';
+
+export const NoAutoSave = () => {
+  return (
+    <>
+      <p>
+        Slate Transcript Editor version: <code>{version}</code>
+      </p>
+      <SlateTranscriptEditor
+        title={DEMO_TITLE_SOLEIO}
+        mediaUrl={text('mediaUrl', DEMO_MEDIA_URL_SOLEIO)}
+        handleSaveEditor={action('handleSaveEditor')}
+        // handleAutoSaveChanges={action('handleAutoSaveChanges')}
+        // https://www.npmjs.com/package/@storybook/addon-knobs#select
+        autoSaveContentType={select('autoSaveContentType', ['digitalpaperedit', 'slate'], 'digitalpaperedit')} // digitalpaperedit or slate - digitalpaperedit, runs alignement before exporting, slate, is just the raw data.
+        // transcriptData={object('transcriptData', DEMO_SOLEIO)}
+        transcriptData={DEMO_SOLEIO}
+      />
+    </>
+  );
+};
+
+export const AutoSave = () => {
+  return (
+    <>
+      <p>
+        Slate Transcript Editor version: <code>{version}</code>
+      </p>
+      <SlateTranscriptEditor
+        title={DEMO_TITLE_SOLEIO}
+        mediaUrl={text('mediaUrl', DEMO_MEDIA_URL_SOLEIO)}
+        handleSaveEditor={action('handleSaveEditor')}
+        handleAutoSaveChanges={action('handleAutoSaveChanges')}
+        // https://www.npmjs.com/package/@storybook/addon-knobs#select
+        autoSaveContentType={select('autoSaveContentType', ['digitalpaperedit', 'slate'], 'digitalpaperedit')} // digitalpaperedit or slate - digitalpaperedit, runs alignement before exporting, slate, is just the raw data.
+        // transcriptData={object('transcriptData', DEMO_SOLEIO)}
+        transcriptData={DEMO_SOLEIO}
+      />
+    </>
+  );
+};

--- a/src/components/SideBtns/index.js
+++ b/src/components/SideBtns/index.js
@@ -23,6 +23,7 @@ function SideBtns({
   handleExport,
   isProcessing,
   isContentModified,
+  isContentSaved,
   setIsProcessing,
   insertTextInaudible,
   handleInsertMusicNote,
@@ -32,6 +33,7 @@ function SideBtns({
   handleRestoreTimecodes,
   handleReplaceText,
   handleSave,
+
   REPLACE_WHOLE_TEXT_INSTRUCTION,
 }) {
   const [anchorMenuEl, setAnchorMenuEl] = useState(null);
@@ -266,7 +268,7 @@ function SideBtns({
 
       <Tooltip title={'save'}>
         <Button disabled={isProcessing} onClick={handleSave} color="primary">
-          <SaveOutlinedIcon color={isContentModified ? 'secondary' : 'primary'} />
+          <SaveOutlinedIcon color={isContentSaved ? 'primary' : 'secondary'} />
         </Button>
       </Tooltip>
 
@@ -295,13 +297,7 @@ function SideBtns({
         title={` Turn ${isPauseWhiletyping ? 'off' : 'on'} pause while typing functionality. As you start typing the media while pause playback
                       until you stop. Not reccomended on longer transcript as it might present performance issues.`}
       >
-        <Button
-          disabled={isProcessing}
-          onClick={handleSetPauseWhileTyping}
-          // variant={isPauseWhiletyping ? 'outlined' : null}
-          // color={isPauseWhiletyping ? 'secondary' : 'primary'}
-          color="primary"
-        >
+        <Button disabled={isProcessing} onClick={handleSetPauseWhileTyping}>
           <PauseOutlinedIcon color="primary" color={isPauseWhiletyping ? 'secondary' : 'primary'} />
         </Button>
       </Tooltip>
@@ -319,7 +315,10 @@ function SideBtns({
           }}
           color="primary"
         >
-          <CachedOutlinedIcon color="primary" />
+          <CachedOutlinedIcon
+            color={'primary'}
+            // color={isContentModified ? 'secondary' : 'primary'}
+          />
         </Button>
       </Tooltip>
 

--- a/src/components/slate-helpers/handle-delete-in-paragraph/index.js
+++ b/src/components/slate-helpers/handle-delete-in-paragraph/index.js
@@ -4,6 +4,10 @@ import isSelectionCollapsed from '../handle-split-paragraph/is-selection-collaps
 import { isTextAndWordsListChanged, alignBlock } from '../../../util/export-adapters/slate-to-dpe/update-timestamps/update-bloocks-timestamps';
 import SlateHelpers from '../index';
 
+/**
+ *
+ * @return {boolean} - to signal if it was suscesfull at splitting to a parent function
+ */
 // TODO: refacto clean up to make more legibl
 function handleDeleteInParagraph({ editor, event }) {
   const { anchor, focus } = editor.selection;
@@ -19,7 +23,7 @@ function handleDeleteInParagraph({ editor, event }) {
       const currentBlockNode = blockNode;
       const currentBlockNumber = path[0];
       if (currentBlockNumber === 0) {
-        return;
+        return false;
       }
 
       const previousBlockNumber = currentBlockNumber - 1;
@@ -92,22 +96,22 @@ function handleDeleteInParagraph({ editor, event }) {
       const newOffset = previousBlockText.length;
       const nextPoint = { offset: newOffset, path: [previousBlockNumber, 0] };
       SlateHelpers.setSelection({ editor, nextPoint });
-      return;
+      return true;
     }
     if (isSelectionCollapsed(anchorOffset, focusOffset)) {
       //  In same block but with selection collapsed
       // event.preventDefault();
-      return;
+      return false;
     } else {
       // In same block but with wide selection
       //   event.preventDefault();
-      return;
+      return false;
     }
   } else {
     event.preventDefault();
     console.info('in different block, not handling this use case for now, and collapsing the selection instead');
     SlateHelpers.collapseSelectionToAsinglePoint(editor);
-    return;
+    return false;
   }
 }
 

--- a/src/components/slate-helpers/handle-split-paragraph/index.js
+++ b/src/components/slate-helpers/handle-split-paragraph/index.js
@@ -15,6 +15,11 @@ import SlateHelpers from '../index';
 import isTextSameAsWordsList from './is-text-same-as-words-list';
 import { isTextAndWordsListChanged, alignBlock } from '../../../util/export-adapters/slate-to-dpe/update-timestamps/update-bloocks-timestamps';
 
+/**
+ *
+ * @param {*} editor slate editor
+ * @return {boolean} - to signal if it was suscesfull at splitting to a parent function
+ */
 function handleSplitParagraph(editor) {
   // get char offset
   const { anchor, focus } = editor.selection;
@@ -24,7 +29,7 @@ function handleSplitParagraph(editor) {
   if (isSameBlock(anchorPath, focusPath)) {
     if (isBeginningOftheBlock(anchorOffset, focusOffset)) {
       console.info('in the same block, but at the beginning of a paragraph for now you are not allowed to create an empty new line');
-      return;
+      return false;
     }
 
     if (isSelectionCollapsed(anchorOffset, focusOffset)) {
@@ -37,7 +42,7 @@ function handleSplitParagraph(editor) {
 
       if (isEndOftheBlock({ anchorOffset, focusOffset, totlaChar: text.split('').length })) {
         console.info('in the same block, but at the end of a paragraph for now you are not allowed to create an empty new line');
-        return;
+        return false;
       }
 
       // if the word have changed. then re-align paragraph before splitting.
@@ -58,7 +63,7 @@ function handleSplitParagraph(editor) {
 
       const isCaretInMiddleOfAword = isTextSameAsWordsList(textBefore, wordsBefore);
       if (isCaretInMiddleOfAword) {
-        return;
+        return false;
       }
       // get start time of first block
       const { speaker, start } = currentBlockNode;
@@ -86,16 +91,16 @@ function handleSplitParagraph(editor) {
         blocks: [blockParagraphBefore, blockParagraphAfter],
         moveSelection: true,
       });
-      return;
+      return true;
     } else {
       console.info('in same block but with wide selection, not handling this use case for now, and collapsing the selection instead');
       SlateHelpers.collapseSelectionToAsinglePoint(editor);
-      return;
+      return false;
     }
   } else {
     console.info('in different block, not handling this use case for now, and collapsing the selection instead');
     SlateHelpers.collapseSelectionToAsinglePoint(editor);
-    return;
+    return false;
   }
 }
 export default handleSplitParagraph;


### PR DESCRIPTION
**Is your Pull Request request related to another issue in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->
fix #44
**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
Fixes save issue #44 where btn indicator goes away on alignment.
Added an extra section in storybook. 


**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->

Ready to merge

once merged needs bumping up version and publishing to npm and the storybook on gh pages

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
Played around with idea of indicating when the content needs alignment, but then decided to comment it out, as to many edge cases. and might just add too much noise to the UI having an extra indicator. Besides if the user saves, it also align so probl better that they do that rather then align without saving.