### PR TITLE
fix: `VTT with speakers` sometimes crashes when there are blanks

### DIFF
--- a/src/util/count-words/index.js
+++ b/src/util/count-words/index.js
@@ -16,6 +16,9 @@ const countWords = (text) => {
   // Don't count multiple spaces as multiple words
   // https://www.w3schools.com/jsref/jsref_regexp_whitespace.asp
   // Do a global search for whitespace characters in a string
+  if (text.length < 1) {
+    return 0;
+  }
   return splitOnWhiteSpaces(text).length;
 };
 


### PR DESCRIPTION
The error is an index-out-of-bounds error at `src/util/export-adapters/subtitles-generator/index.js:35`

```
Uncaught (in promise) TypeError: Cannot read property 'end' of undefined
    at index.js:35
    at Array.map (<anonymous>)
    at addTimecodesToLines (index.js:28)
    at preSegmentTextJson (index.js:86)
    at subtitlesComposer (index.js:95)
    at exportAdapter (index.js:61)
```

The issue appears to be that blank lines (paragraphs, I think? Maybe sentences, or chunks as needed for screen-presentable subtitles?) were being treated as having one word in them, causing an out-of-bounds array access.