### PR TITLE
fixes issue #28 - VTT speakers and paragraphs export broken

### DIFF
--- a/src/util/export-adapters/index.js
+++ b/src/util/export-adapters/index.js
@@ -45,6 +45,7 @@ const exportAdapter = ({ slateValue, type, ext, transcriptTitle, speakers, timec
           words: editorContent.words,
           paragraphs: editorContent.paragraphs,
           type,
+          slateValue,
         });
         return subtitlesJson;
       }


### PR DESCRIPTION
**Is your Pull Request request related to another issue in this repository ?**      
<!-- _If so please link to other issues and PRs as appropriate_ -->

Issue https://github.com/pietrop/slate-transcript-editor/issues/28
PR https://github.com/pietrop/slate-transcript-editor/pull/48

**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
after recent changes in alignment logic, passes slate value and uses the slate paragraph blocks to create the subtitles json to pass to the vtt generator to preserve the text editor paragraphs in the vtt etc..


**State whether the PR is ready for review or whether it needs extra work**    
<!-- _If you are still working on it and just setting it up for later review, or if it's ready to be reviewed for merging_ -->
Ready for review

**Additional context**    
<!-- Add any other context or screenshots about the PR. -->
I could use some help testing/double checking it this doesn't introduce bugs in the subtitles creation for vtt. 
Eg by using the slateJs value content. Does it create probls if the content has not recently being aligned?

I am thinking no, coz the start and end time of paragraphs is generally preserved even if the text in the paragraphs is modified etc.. but would like a second opinion 😄 