### PR TITLE
fix: OHMS export

### DIFF
--- a/src/util/insert-timecodes-in-line-in-words-list/index.js
+++ b/src/util/insert-timecodes-in-line-in-words-list/index.js
@@ -8,31 +8,42 @@ import { shortTimecode } from '../timecode-converter';
  * `slate-transcript-editor` OHMS export option exports the word part.
  * Thi functions organises the words to add timecodes intervals at the required times.
  */
+
 import convertWordsToText from '../convert-words-to-text';
 
-const insertTimecodesInlineinWordsList = ({ intervalSeconds = 30, words }) => {
+const insertTimecodesInlineinWordsList = ({ intervalSeconds = 30, words, lastInsertTime = 0 }) => {
   const tmpWords = JSON.parse(JSON.stringify(words));
-  let lastInsertTime = 0;
-
   const sortedWords = tmpWords.sort((a, b) => a.start - b.start);
-
   let newWords = [];
+
   for (const word of sortedWords) {
     if (word.start - lastInsertTime > intervalSeconds) {
       lastInsertTime = Math.floor(word.start / intervalSeconds) * intervalSeconds;
       const timecode = shortTimecode(lastInsertTime);
-      newWords.push({ start: word.start, end: word.start + (word.end - word.start) / 2, text: `[${timecode}]` });
+      newWords.push({
+        start: word.start,
+        end: word.start + (word.end - word.start) / 2,
+        text: `[${timecode}]`,
+      });
       word.start = word.start + (word.end - word.start) / 2;
     }
+
     newWords.push(word);
   }
-  return newWords;
+
+  return [newWords, lastInsertTime];
 };
 
 const insertTimecodesInLineInSlateJs = (slateValue) => {
+  let lastInsertTime = 0;
   return slateValue.map((block) => {
     const newBlock = JSON.parse(JSON.stringify(block));
-    newBlock.children[0].words = insertTimecodesInlineinWordsList({ words: newBlock.children[0].words });
+    const [newWords, lastInsert] = insertTimecodesInlineinWordsList({
+      words: newBlock.children[0].words,
+      lastInsertTime,
+    });
+    lastInsertTime = lastInsert;
+    newBlock.children[0].words = newWords;
     newBlock.children[0].text = convertWordsToText(newBlock.children[0].words);
     return newBlock;
   });


### PR DESCRIPTION
Since alignment is running on paragraphs instead of the whole document, the code to inject timecodes inline was starting from the beginning of each paragraph, instead of continuing from where it left off in the previous paragraph.

Before: 
![Screen Shot 2021-03-14 at 3 36 58 PM](https://user-images.githubusercontent.com/4368270/111081727-1e8a0c80-84db-11eb-8a27-d37647f28013.png)

After:

![Screen Shot 2021-03-14 at 3 37 16 PM](https://user-images.githubusercontent.com/4368270/111081737-28ac0b00-84db-11eb-821f-ee854f4f49bc.png)

